### PR TITLE
chore: jx-go-loops2 to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,6 +10,9 @@ dependencies:
 - name: js-jx-start
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: jx-go-loops2
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: jxknative
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
chore: Promote jx-go-loops2 to version 0.0.1